### PR TITLE
feat: add heap dump support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,40 @@ Used to spawn a `bfx-svc-js` service. Contains the worker CLI.
 ```
 wtype         worker name, e.g. wrk-util-net-api
 env           production or development
-debug         enable debug mode
+debug         enable debug mode, with heap dump support
 
 For workers that require a port:
 
 apiPort       port to listen on, e.g. 8721
+```
+
+## Heap dumps
+
+Memory snapshots can be loaded in Chrome. Open developer tools, go to the `Memory` tab, click: `Load profile...`. You can load multiple snapshots and diff them.
+
+
+To enable Memory Snapshot support, start the service with the `--debug` flag.
+
+A snapshot is written each time the process receives a `SIGUSR2` signal.
+
+```
+$ kill -USR2 <pid>
+```
+**Example:**
+
+```
+# start service with heap dump support
+$ node worker.js --env=development --wtype=wrk-util-net-api --apiPort 8721 --debug=true
+
+# do some operations, e.g. multiple requests
+
+# then take first snapshot
+$ ps -A | grep util-net-api
+70833 ttys001    0:01.23 wrk-util-net-api-70833
+
+$ kill -USR2 70833
+
+# heapdump-258886655.138372.heapsnapshot file appears in service dir
+
+# repeat sending signal if you want to compare snapshots
 ```

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -43,6 +43,12 @@ const cmd = require('yargs')
 
 const wtype = cmd.wtype
 const env = cmd.env
+const debug = cmd.debug
+
+let heapdump
+if (debug) {
+  heapdump = require('heapdump')
+}
 
 const conf = _.merge(
   {},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Robert Kowalski <robert@bitfinex.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "heapdump": "^0.3.9",
     "lodash": "^4.17.4",
     "yargs": "^9.0.1"
   }


### PR DESCRIPTION
Heap dumps enable us to compare memory snapshots to find memory
leaks in services.

--- 

## Heap dumps

Memory snapshots can be loaded in Chrome. Open developer tools, go to the `Memory` tab, click: `Load profile...`. You can load multiple snapshots and diff them.


To enable Memory Snapshot support, start the service with the `--debug` flag.

A snapshot is written each time the process receives a `SIGUSR2` signal.

```
$ kill -USR2 <pid>
```
**Example:**

```
# start service with heap dump support
$ node worker.js --env=development --wtype=wrk-util-net-api --apiPort 8721 --debug=true

# do some operations, e.g. multiple requests

# then take first snapshot
$ ps -A | grep util-net-api
70833 ttys001    0:01.23 wrk-util-net-api-70833

$ kill -USR2 70833

# heapdump-258886655.138372.heapsnapshot file appears in service dir

# repeat sending signal if you want to compare snapshots
```