### PR TITLE
 ctx: add file path of worker to ctx 

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -57,10 +57,13 @@ const conf = _.merge(
 )
 
 const wref = wtype.split('-').reverse()
+const workerFile = path.join(serviceRoot, '/workers/', wref.join('.'))
+
 const ctx = {
   root: serviceRoot,
   wtype: wtype,
-  env: env
+  env: env,
+  worker: workerFile
 }
 
 _.each(cmd, (v, k) => {
@@ -71,7 +74,7 @@ const pname = [wtype]
 pname.push(process.pid)
 process.title = pname.join('-')
 
-const HandlerClass = require(path.join(serviceRoot, '/workers/', wref.join('.')))
+const HandlerClass = require(workerFile)
 const hnd = new HandlerClass(conf, ctx)
 
 let shutdown = 0

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -45,6 +45,7 @@ const wtype = cmd.wtype
 const env = cmd.env
 const debug = cmd.debug
 
+// eslint-disable-next-line no-unused-vars
 let heapdump
 if (debug) {
   heapdump = require('heapdump')

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "heapdump": "^0.3.9",
     "lodash": "^4.17.4",
     "yargs": "^9.0.1"
+  },
+  "devDependencies": {
+    "standard": "^11.0.1"
   }
 }


### PR DESCRIPTION
this adds the filepath of the inititated worker to the context.
this is useful for several things, for me it is the most flexible
way to detect the file name of the corresponding `loc.api` api
filehandler via `getApiConf`.

This way we can remove `getApiConf` from most workers. The method
just needs extension in special cases. `wrk-api` would receive
the current worker, construct the correpsonding loc.api filename
from it, and return it in `getApiConf`.