### PR TITLE
decouple cli and worker spinup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,22 @@
-const worker = require('./lib/worker.js')
+'use strict'
+
+const cmd = require('yargs')
+  .option('wtype', {
+    demand: true,
+    type: 'string'
+  })
+  .option('env', {
+    choices: ['production', 'development'],
+    demand: true,
+    type: 'string'
+  })
+  .option('debug', {
+    default: false,
+    type: 'boolean'
+  })
+  .help('help')
+  .argv
+
+const worker = require('./lib/worker.js')(cmd)
 
 module.exports = worker

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -24,72 +24,62 @@ const getJSONConf = (env, type, path) => {
 
 process.env.TZ = 'UTC'
 
-const cmd = require('yargs')
-  .option('wtype', {
-    demand: true,
-    type: 'string'
-  })
-  .option('env', {
-    choices: ['production', 'development'],
-    demand: true,
-    type: 'string'
-  })
-  .option('debug', {
-    default: false,
-    type: 'boolean'
-  })
-  .help('help')
-  .argv
+function worker (cmd) {
+  const wtype = cmd.wtype
+  const env = cmd.env
+  const debug = cmd.debug
+  const serviceRoot = cmd.serviceRoot || path.dirname(require.main.filename)
 
-const wtype = cmd.wtype
-const env = cmd.env
-const debug = cmd.debug
+  // eslint-disable-next-line no-unused-vars
+  let heapdump
+  if (debug) {
+    heapdump = require('heapdump')
+  }
 
-// eslint-disable-next-line no-unused-vars
-let heapdump
-if (debug) {
-  heapdump = require('heapdump')
+  const conf = _.merge(
+    {},
+    getJSONConf(env, null, `${serviceRoot}/config/common.json`)
+  )
+
+  const wref = wtype.split('-').reverse()
+  const workerFile = path.join(serviceRoot, '/workers/', wref.join('.'))
+
+  const ctx = {
+    root: serviceRoot,
+    wtype: wtype,
+    env: env,
+    worker: workerFile
+  }
+
+  _.each(cmd, (v, k) => {
+    ctx[_.camelCase(k)] = v
+  })
+
+  const pname = [wtype]
+  pname.push(process.pid)
+  process.title = pname.join('-')
+
+  const HandlerClass = require(workerFile)
+  const hnd = new HandlerClass(conf, ctx)
+
+  let shutdown = 0
+
+  process.on('SIGINT', () => {
+    if (shutdown) {
+      return
+    }
+    shutdown = 1
+
+    if (!hnd.active) {
+      return
+    }
+    console.log('BKW', pname, 'shutting down')
+    hnd.stop(() => {
+      process.exit()
+    })
+  })
+
+  return hnd
 }
 
-const conf = _.merge(
-  {},
-  getJSONConf(env, null, `${serviceRoot}/config/common.json`)
-)
-
-const wref = wtype.split('-').reverse()
-const workerFile = path.join(serviceRoot, '/workers/', wref.join('.'))
-
-const ctx = {
-  root: serviceRoot,
-  wtype: wtype,
-  env: env,
-  worker: workerFile
-}
-
-_.each(cmd, (v, k) => {
-  ctx[_.camelCase(k)] = v
-})
-
-const pname = [wtype]
-pname.push(process.pid)
-process.title = pname.join('-')
-
-const HandlerClass = require(workerFile)
-const hnd = new HandlerClass(conf, ctx)
-
-let shutdown = 0
-
-process.on('SIGINT', () => {
-  if (shutdown) {
-    return
-  }
-  shutdown = 1
-
-  if (!hnd.active) {
-    return
-  }
-  console.log('BKW', pname, 'shutting down')
-  hnd.stop(() => {
-    process.exit()
-  })
-})
+module.exports = worker


### PR DESCRIPTION
this decouples the cli argument parsing from the actual spinup of
the worker.

this way we can prgramatically start and stop svc services,
without the need to spawn a child process.