### PR TITLE
move sigtrap out of programmatic api

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,22 @@ const cmd = require('yargs')
   .help('help')
   .argv
 
-const worker = require('./lib/worker.js')(cmd)
+const hnd = require('./lib/worker.js')(cmd)
 
-module.exports = worker
+let shutdown = 0
+process.on('SIGINT', () => {
+  if (shutdown) {
+    return
+  }
+  shutdown = 1
+
+  if (!hnd.active) {
+    return
+  }
+  console.log('BKW', process.title, 'shutting down')
+  hnd.stop(() => {
+    process.exit()
+  })
+})
+
+module.exports = hnd

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -3,7 +3,6 @@
 const path = require('path')
 const _ = require('lodash')
 const fs = require('fs')
-const serviceRoot = path.dirname(require.main.filename)
 
 const getJSONConf = (env, type, path) => {
   const conf = JSON.parse(fs.readFileSync(path, 'utf8'))
@@ -61,23 +60,6 @@ function worker (cmd) {
 
   const HandlerClass = require(workerFile)
   const hnd = new HandlerClass(conf, ctx)
-
-  let shutdown = 0
-
-  process.on('SIGINT', () => {
-    if (shutdown) {
-      return
-    }
-    shutdown = 1
-
-    if (!hnd.active) {
-      return
-    }
-    console.log('BKW', pname, 'shutting down')
-    hnd.stop(() => {
-      process.exit()
-    })
-  })
 
   return hnd
 }


### PR DESCRIPTION
this lets other services shut down, if the worker was spawned
via api and not cli.