### PR TITLE
add ssl flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Used to spawn a `bfx-svc-js` service. Contains the worker CLI.
 wtype         worker name, e.g. wrk-util-net-api
 env           production or development
 debug         enable debug mode, with heap dump support
+ssl           ssl flag
 
 For workers that require a port:
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const cmd = require('yargs')
     default: false,
     type: 'boolean'
   })
+  .option('ssl', {
+    type: 'boolean'
+  })
   .help('help')
   .argv
 


### PR DESCRIPTION
when setting `ssl=false` yargs parses it as a string. this leads to
code like this in ACL apps, where i want to be able to disable ssl
in `development`:

```js
  getBaseAddress () {
    if (this.ctx.ssl === 'false' && this.ctx.env !== 'development') {
      throw new Error('ERR_SSL_DEV: disabling SSL via commandline not possible in production')
    }

    if (this.ctx.ssl === 'false' && this.ctx.env === 'development') {
      return 'sec:rest:foo'
    }

    return 'rest:foo'
  }
```

the patch parsesinput from `--ssl=` as boolean.

useful for development of ACL apps.