### PR TITLE
fix: handle shutdown before worker activation

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,21 +18,10 @@ const cmd = require('yargs')
   .argv
 
 const hnd = require('./lib/worker.js')(cmd)
+const createShutdownHandler = require('./lib/shutdown')
 
-let shutdown = 0
-process.on('SIGINT', () => {
-  if (shutdown) {
-    return
-  }
-  shutdown = 1
-
-  if (!hnd.active) {
-    return
-  }
-  console.log('BKW', process.title, 'shutting down')
-  hnd.stop(() => {
-    process.exit()
-  })
-})
+const shutdown = createShutdownHandler(hnd)
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
 
 module.exports = hnd

--- a/lib/shutdown.js
+++ b/lib/shutdown.js
@@ -1,0 +1,24 @@
+'use strict'
+
+function createShutdownHandler (hnd, exit = process.exit, log = console.log) {
+  let shutdown = 0
+
+  return () => {
+    if (shutdown) {
+      return
+    }
+    shutdown = 1
+
+    if (!hnd.active) {
+      exit(0)
+      return
+    }
+
+    log('BKW', process.title, 'shutting down')
+    hnd.stop(() => {
+      exit(0)
+    })
+  }
+}
+
+module.exports = createShutdownHandler

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6,6 +6,7 @@ const path = require('path')
 const fs = require('fs')
 
 const worker = require('../lib/worker')
+const createShutdownHandler = require('../lib/shutdown')
 const fixtureWorker = path.join(__dirname, 'fixtures', 'workers', 'dummy.js')
 
 async function setupDir (t) {
@@ -101,5 +102,49 @@ test('config priority order', async (t) => {
 
     const wrk = run(dir, 'production')
     t.is(wrk.conf.source, 'env-json')
+  })
+})
+
+test('shutdown handler', async (t) => {
+  await t.test('exits immediately when worker is not active', (t) => {
+    let exitCode = null
+    let stopCalled = false
+    const hnd = {
+      active: 0,
+      stop: () => {
+        stopCalled = true
+      }
+    }
+
+    const shutdown = createShutdownHandler(hnd, code => {
+      exitCode = code
+    }, () => {})
+
+    shutdown()
+
+    t.is(stopCalled, false)
+    t.is(exitCode, 0)
+  })
+
+  await t.test('stops active worker once before exiting', (t) => {
+    let exitCode = null
+    let stopCalls = 0
+    const hnd = {
+      active: 1,
+      stop: cb => {
+        stopCalls++
+        cb()
+      }
+    }
+
+    const shutdown = createShutdownHandler(hnd, code => {
+      exitCode = code
+    }, () => {})
+
+    shutdown()
+    shutdown()
+
+    t.is(stopCalls, 1)
+    t.is(exitCode, 0)
   })
 })


### PR DESCRIPTION
## Summary
- add a shared shutdown handler for SIGINT and SIGTERM
- exit cleanly if a shutdown signal arrives before the worker becomes active
- keep the existing hnd.stop() path for active workers

## Why
If a process is stopped while it is still booting, it should not wait for the process manager hard kill timeout.

## Testing
- npm test