### PR TITLE
chore: bump package version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitfinex/bfx-svc-boot-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitfinex/bfx-svc-boot-js",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/bfx-svc-boot-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Worker CLI for svc-js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump @bitfinex/bfx-svc-boot-js from 1.3.0 to 1.3.1
- update package-lock.json to match

## Why
This publishes the merged shutdown handler changes as a new patch release so downstream services can consume them from npm.

## Testing
- npm test